### PR TITLE
JSDocs lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,15 @@
+'use strict';
+
+/**
+ * @file    Manages the ESLint rules
+ * @author  Fimion
+ */
+
 module.exports = {
   extends: [
     'tjw-base',
-    'tjw-import'
-    // 'tjw-jsdoc'
+    'tjw-import',
+    'tjw-jsdoc'
   ],
   globals: {
     Promise: true,
@@ -10,5 +17,7 @@ module.exports = {
     Reflect: true
   },
   rules: {
+    'jsdoc/check-examples': 'off',
+    'jsdoc/require-example': 'off'
   }
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "eslint": "^8.11.0",
     "eslint-config-tjw-base": "^2.0.0",
     "eslint-config-tjw-import": "^1.0.0",
+    "eslint-config-tjw-jsdoc": "^1.0.0",
     "eslint-plugin-import": "^2.25.4",
+    "eslint-plugin-jsdoc": "^38.0.4",
     "sass": "^1.43.4",
     "vite": "^2.6.4"
   }

--- a/src/ge-background.js
+++ b/src/ge-background.js
@@ -1,3 +1,10 @@
+'use strict';
+
+/**
+ * @file    Handles CSS background properties``
+ * @author  Fimion
+ */
+
 import { geoExtendElement, parseSimpleColor } from './ge-shared.js';
 
 const BACKGROUND_ATTRS = {
@@ -14,6 +21,9 @@ class GeoElementBackground extends geoExtendElement(
 ) {
   #a11y;
 
+  /**
+   * Constructor description.
+   */
   constructor () {
     super();
     // this.#wrapper.classList.add("background");
@@ -24,6 +34,9 @@ class GeoElementBackground extends geoExtendElement(
     this.shadowRoot.append(this.#a11y);
   }
 
+  /**
+   * Set style description.
+   */
   #setStyle () {
     const image = (this.attrs.background).replaceAll(
       '\'',
@@ -63,6 +76,9 @@ class GeoElementBackground extends geoExtendElement(
     `;
   }
 
+  /**
+   * Attribute changed callback description.
+   */
   attributeChangedCallback () {
     this.#setStyle();
   }

--- a/src/ge-background.js
+++ b/src/ge-background.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * @file    Handles CSS background properties``
+ * @file    Handles CSS background properties
  * @author  Fimion
  */
 

--- a/src/ge-blink.js
+++ b/src/ge-blink.js
@@ -1,6 +1,24 @@
+'use strict';
+
+/**
+ * @file    Recreates the web 1.0 "Blink" feature
+ * @author  Fimion
+ */
+
 import { geoExtendElement } from './ge-shared.js';
 
+/**
+ * Geo extend element description.
+ *
+ * @param  {[type]} 'ge-blink'  [description]
+ * @return {[type]}             [description]
+ */
 export default class GeoElementBlink extends geoExtendElement('ge-blink') {
+  /**
+   * Constructor description.
+   *
+   * @return {[type]} description
+   */
   constructor () {
     super();
     this.css`

--- a/src/ge-center.js
+++ b/src/ge-center.js
@@ -1,6 +1,24 @@
+'use strict';
+
+/**
+ * @file    Forces element to block display and centers the contents using text-align
+ * @author  Fimion
+ */
+
 import { geoExtendElement } from './ge-shared.js';
 
+/**
+ * Geo extend element description.
+ *
+ * @param  {[type]} 'ge-center'  [description]
+ * @return {[type]}              [description]
+ */
 export default class GeoElementCenter extends geoExtendElement('ge-center') {
+  /**
+   * Constructor description.
+   *
+   * @return {[type]} [description]
+   */
   constructor () {
     super();
     this.css`slot{display:block; text-align:center}`;

--- a/src/ge-font.js
+++ b/src/ge-font.js
@@ -1,11 +1,31 @@
+'use strict';
+
+/**
+ * @file    Handles CSS font styling
+ * @author  Fimion
+ */
+
 import { geoExtendElement, parseCSSList, parseSimpleColor } from './ge-shared.js';
 
+/**
+ * Geo extend element description.
+ *
+ * @param  {string} 'ge-font'      [description]
+ * @param  {[type]} HTMLElement    [description]
+ * @param  {Array}  options.attrs  [description]
+ * @return {[type]}                [description]
+ */
 export default class GeoElementFont extends geoExtendElement(
   'ge-font',
   HTMLElement,
   { attrs: ['face', 'color', 'size'] }
 ) {
   #links;
+  /**
+   * Constructor description.
+   *
+   * @return {[type]} [description]
+   */
   constructor () {
     super();
     this.#links = this.jj.style;
@@ -13,14 +33,26 @@ export default class GeoElementFont extends geoExtendElement(
     document.head.appendChild(this.#links);
   }
 
+  /**
+   * Attribute changed callback description.
+   */
   attributeChangedCallback () {
     this.#updateStyles();
   }
 
+  /**
+   * Create style link description.
+   *
+   * @param  {[type]} href  [description]
+   * @return {[type]}       [description]
+   */
   #createStyleLink (href) {
     return `@import url(${href});`;
   }
 
+  /**
+   * Update styles description.
+   */
   #updateStyles () {
     const face = parseCSSList(this.attrs.face);
     const imports = [];

--- a/src/ge-img.js
+++ b/src/ge-img.js
@@ -1,3 +1,10 @@
+'use strict';
+
+/**
+ * @file    Handles image related HTML attributes and CSS properties
+ * @author  Fimion
+ */
+
 import { geoExtendElement } from './ge-shared.js';
 
 const IMG_ATTRS = [
@@ -12,6 +19,15 @@ const IMG_ATTRS = [
 
 const DIALUP_TIME = 10000;
 
+/**
+ * Geo extend element description.
+ *
+ * @param  {string}  'ge-img'        [description]
+ * @param  {[type]}  HTMLElement     [description]
+ * @param  {Array}   options.attrs   [description]
+ * @param  {boolean} options.noSlot  [description]
+ * @return {[type]}                  [description]
+ */
 export default class GeoElementImage extends geoExtendElement(
   'ge-img',
   HTMLElement,
@@ -22,6 +38,11 @@ export default class GeoElementImage extends geoExtendElement(
 
   static #promiseList = [Promise.resolve()];
 
+  /**
+   * Constructor description.
+   *
+   * @return {[type]} [description]
+   */
   constructor () {
     super();
 
@@ -43,6 +64,11 @@ export default class GeoElementImage extends geoExtendElement(
     this.shadowRoot.append(this.#image, this.#placeHolder);
   }
 
+  /**
+   * Attribute changed callback description.
+   *
+   * @param {[type]} attr  [description]
+   */
   attributeChangedCallback (attr/* , oldValue, newValue */) {
     this.updateImage();
     if (attr === 'src' || attr === 'srcset') {
@@ -50,20 +76,39 @@ export default class GeoElementImage extends geoExtendElement(
     }
   }
 
+  /**
+   * Animation offset promise description.
+   *
+   * @param  {Promise} finished  [description]
+   * @return {Promise}           [description]
+   */
   #animationOffsetPromise (finished) {
     return new Promise((resolve) => {
       finished.then((result) => resolve(result));
     });
   }
 
+  /**
+   * Animation offset description.
+   *
+   * @param {[type]} finished  [description]
+   */
   set #animationOffset (finished) {
     GeoElementImage.#promiseList.push(this.#animationOffsetPromise(finished));
   }
 
+  /**
+   * Animation offset description.
+   *
+   * @return {[type]} [description]
+   */
   get #animationOffset () {
     return GeoElementImage.#promiseList[GeoElementImage.#promiseList.length - 1];
   }
 
+  /**
+   * Update image description.
+   */
   updateImage () {
     IMG_ATTRS.forEach((attr) => {
       if (this.hasAttribute(attr)) {
@@ -72,6 +117,9 @@ export default class GeoElementImage extends geoExtendElement(
     });
   }
 
+  /**
+   * Update animation description.
+   */
   updateAnimation () {
     this.shadowRoot.append(this.#placeHolder);
     this.#image.classList.add('loading');

--- a/src/ge-marquee.js
+++ b/src/ge-marquee.js
@@ -1,3 +1,10 @@
+'use strict';
+
+/**
+ * @file    Recreates the web 1.0 "Marquee" feature
+ * @author  Fimion
+ */
+
 import { geoExtendElement } from './ge-shared.js';
 
 const MARQUEE_ATTRS = {
@@ -15,6 +22,14 @@ const MARQUEE_ATTRS = {
 };
 
 
+/**
+ * Geo extend element description.
+ *
+ * @param  {[type]} 'ge-marquee'   [description]
+ * @param  {[type]} HTMLElement    [description]
+ * @param  {Array}  options.attrs  [description]
+ * @return {[type]}                [description]
+ */
 export default class GeoElementMarqee extends geoExtendElement(
   'ge-marquee',
   HTMLElement,
@@ -24,6 +39,11 @@ export default class GeoElementMarqee extends geoExtendElement(
   #currentAnimation;
   #reducedMotion;
 
+  /**
+   * Constructor description.
+   *
+   * @return {[type]} [description]
+   */
   constructor () {
     super();
     this.css`
@@ -64,6 +84,11 @@ export default class GeoElementMarqee extends geoExtendElement(
     this.#reducedMotion.addEventListener('change', this.#updateScroll.bind(this));
   }
 
+  /**
+   * Get scroll width description.
+   *
+   * @return {[type]} [description]
+   */
   #getScrollWidth () {
     const div = this.jj.div;
     div.innerText = this.innerText;
@@ -73,6 +98,9 @@ export default class GeoElementMarqee extends geoExtendElement(
     return mySize;
   }
 
+  /**
+   * Update scroll description.
+   */
   #updateScroll () {
     const scrollAmount = Number(this.attrs.scrollamount);
     const trueSpeed = typeof this.attrs.truespeed === 'string';
@@ -135,10 +163,16 @@ export default class GeoElementMarqee extends geoExtendElement(
     });
   }
 
+  /**
+   * Connected callback description.
+   */
   connectedCallback () {
     this.#updateScroll();
   }
 
+  /**
+   * Attribute changed callback description.
+   */
   attributeChangedCallback (/* key */) {
     this.#updateScroll();
   }

--- a/src/ge-shared.js
+++ b/src/ge-shared.js
@@ -1,6 +1,19 @@
+'use strict';
+
+/**
+ * @file    Shared/Reusable helpers
+ * @author  Fimion
+ */
+
 // Stolen from https://stackoverflow.com/a/39597017
 const PARSE_CSS_LIST = /,(?=(?:(?:[^"']*"[^"']*")|(?:[^'"]*'[^'"]*'))*[^"']*$)/g;
 
+/**
+ * Parse CSS list description.
+ *
+ * @param  {[type]} value  [description]
+ * @return {[type]}        [description]
+ */
 export function parseCSSList (value) {
   if (typeof value !== 'string') {
     return [];
@@ -13,16 +26,24 @@ export function parseCSSList (value) {
 
 const COLOR_PARSE_REGEX = /((^[\w]+$)|(^\#[a-f\d]{3,6}$))/i;
 
+/**
+ * Parse simple color description.
+ *
+ * @param  {[type]} colorString  [description]
+ * @param  {[type]} def          [description]
+ * @return {[type]}              [description]
+ */
 export function parseSimpleColor (colorString, def = undefined) {
   return COLOR_PARSE_REGEX.test(colorString) ? colorString : def;
 }
 
 /**
+ * Geo extend element description.
  *
- * @param {string} elementName
- * @param {HTMLElement} nativeElement
- * @param {object} options
- * @returns {HTMLElement}
+ * @param  {string}      elementName    [description]
+ * @param  {HTMLElement} nativeElement  [description]
+ * @param  {object}      options        [description]
+ * @return {HTMLElement}                [description]
  */
 export function geoExtendElement (elementName, nativeElement = HTMLElement, options = {}) {
   const { attrs, noSlot } = options;
@@ -122,9 +143,11 @@ export function geoExtendElement (elementName, nativeElement = HTMLElement, opti
     }
 
     /**
+     * Template style description.
      *
-     * @param {Object<String,String>} values
-     * @param {String} styles
+     * @param  {object<string, string>} values  [description]
+     * @param  {string}                 styles  [description]
+     * @return {[type]}                         [description]
      */
     __templateStyle (values, styles) {
       return Object.keys(values).reduce((output, input) => {

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,9 @@
+'use strict';
+/**
+ * @file    Entry point for the library. Exposes the external facing function that accepts the input defined in the API documentation.
+ * @author  TheJaredWilcurt
+ */
+
 import GeoElementBackground from './ge-background.js';
 import GeoElementBlink from './ge-blink.js';
 import GeoElementCenter from './ge-center.js';

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-extraneous-dependencies, import/no-anonymous-default-export, import/no-unused-modules */
+/* eslint-disable import/no-extraneous-dependencies, import/no-anonymous-default-export, import/no-unused-modules, jsdoc/require-file-overview */
 import { defineConfig } from 'vite';
 
 export default defineConfig({

--- a/vite.docs.js
+++ b/vite.docs.js
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-extraneous-dependencies, import/no-anonymous-default-export, import/no-unused-modules */
+/* eslint-disable import/no-extraneous-dependencies, import/no-anonymous-default-export, import/no-unused-modules, jsdoc/require-file-overview */
 import { defineConfig } from 'vite';
 
 export default defineConfig({


### PR DESCRIPTION
What's nice about using the JSDoc's linter is that it catches when you change a function. If you add/remove/rename arguments or add/remove a `return` and the comment is out-of-sync, the linter will alert you to update it too. Useful for contributors as well.

You'll need to go through and update the types and descriptions. I'm not familiar enough with the code to do that myself. If having others be able to contribute easily is important, then filling out the descriptions for functions and arguments will really help with that.

